### PR TITLE
feat: Add Bearer token authentication to protected API endpoints

### DIFF
--- a/hypegit/DEPLOYMENT.md
+++ b/hypegit/DEPLOYMENT.md
@@ -187,7 +187,9 @@ wrangler r2 object list hypegit-snapshots --prefix trending/
 - `GET /api/test-scrape` - Test scraping (debug endpoint)
 
 **Authentication:**
-All protected endpoints require a Bearer token in the Authorization header:
+All protected endpoints require a Bearer token in the Authorization header. You can use either:
+1. **Database API Keys** - Managed keys stored in the database (recommended)
+2. **ADMIN_API_KEY** - Legacy super admin key from environment secrets
 
 ```bash
 curl -X POST "https://hypegit.andrew-kim0810.workers.dev/api/refresh" \
@@ -227,6 +229,74 @@ Invalid token:
   "error": "Unauthorized",
   "message": "Invalid API key"
 }
+```
+
+### Admin Endpoints (Super Admin Only)
+
+**API Key Management:**
+These endpoints require the ADMIN_API_KEY (not regular database keys):
+
+- `POST /admin/keys` - Create a new API key
+- `GET /admin/keys` - List all API keys
+- `DELETE /admin/keys/:id` - Deactivate an API key
+- `POST /admin/keys/:id/reactivate` - Reactivate an API key
+- `DELETE /admin/keys/:id/permanent` - Permanently delete an API key
+
+**Creating an API key:**
+
+```bash
+curl -X POST "https://hypegit.andrew-kim0810.workers.dev/admin/keys" \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "CI/CD Pipeline",
+    "description": "Key for automated deployments",
+    "created_by": "admin@example.com"
+  }'
+```
+
+Response:
+```json
+{
+  "success": true,
+  "message": "API key created successfully. Save this key - it will not be shown again!",
+  "key": "rT9kL2mN8pQ5vR7sY3wA4bX6cH1dE0fG...",
+  "info": {
+    "id": "uuid-here",
+    "name": "CI/CD Pipeline",
+    "description": "Key for automated deployments",
+    "created_at": "2025-10-07T15:30:00.000Z",
+    "last_used": null,
+    "is_active": true,
+    "created_by": "admin@example.com"
+  }
+}
+```
+
+**Listing API keys:**
+
+```bash
+# List active keys only
+curl "https://hypegit.andrew-kim0810.workers.dev/admin/keys" \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY"
+
+# Include inactive keys
+curl "https://hypegit.andrew-kim0810.workers.dev/admin/keys?include_inactive=true" \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY"
+```
+
+**Deactivating a key:**
+
+```bash
+curl -X DELETE "https://hypegit.andrew-kim0810.workers.dev/admin/keys/uuid-here" \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY"
+```
+
+**Permanently deleting a key:**
+
+```bash
+curl -X DELETE "https://hypegit.andrew-kim0810.workers.dev/admin/keys/uuid-here/permanent" \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY"
 ```
 
 ## Troubleshooting

--- a/hypegit/DEPLOYMENT.md
+++ b/hypegit/DEPLOYMENT.md
@@ -60,9 +60,23 @@ bun run db:migrate:remote
 wrangler secret put GITHUB_TOKEN
 # When prompted, paste your GitHub Personal Access Token
 
+# Set API key for admin endpoints (REQUIRED)
+wrangler secret put ADMIN_API_KEY
+# When prompted, paste a strong random key (32+ characters)
+# Example: openssl rand -base64 32
+
 # Set environment name (optional)
 wrangler secret put ENVIRONMENT
 # Enter: production
+```
+
+**Generating a secure API key:**
+```bash
+# macOS/Linux
+openssl rand -base64 32
+
+# Or use a password generator
+# Example: xK9mP2vL8nQ5wR7tY3zA4bN6cH1dF0eG
 ```
 
 ### 7. Build the Worker
@@ -145,21 +159,75 @@ wrangler r2 object list hypegit-snapshots --prefix trending/
 
 ## API Endpoints
 
-### Health & Info
+### Public Endpoints (No Authentication Required)
+
+**Health & Info:**
 - `GET /` - Root info
 - `GET /health` - Health check with stats
 
-### Repositories
+**Repositories:**
 - `GET /api/repos?limit=50&active_only=true` - List repos
 - `GET /api/repos/:owner/:name` - Repo details
 - `GET /api/repos/:owner/:name/trending?limit=30` - Trending history
 - `GET /api/repos/:owner/:name/stars?limit=100` - Star snapshots
 
-### Trending
+**Trending:**
 - `GET /api/trending?time_range=daily&language=typescript&limit=50` - Current trending
 
-### Statistics
+**Statistics:**
 - `GET /api/stats` - Platform stats
+
+### Protected Endpoints (Authentication Required)
+
+**Manual Scraping:**
+- `POST /api/refresh` - Trigger background scrape
+- `POST /api/refresh-sync?language=go&range=daily` - Synchronous scrape
+
+**Testing:**
+- `GET /api/test-scrape` - Test scraping (debug endpoint)
+
+**Authentication:**
+All protected endpoints require a Bearer token in the Authorization header:
+
+```bash
+curl -X POST "https://hypegit.andrew-kim0810.workers.dev/api/refresh" \
+  -H "Authorization: Bearer YOUR_API_KEY_HERE"
+```
+
+**Example authenticated requests:**
+
+```bash
+# Trigger manual refresh (background)
+curl -X POST "https://hypegit.andrew-kim0810.workers.dev/api/refresh" \
+  -H "Authorization: Bearer xK9mP2vL8nQ5wR7tY3zA4bN6cH1dF0eG"
+
+# Trigger synchronous scrape for specific language
+curl -X POST "https://hypegit.andrew-kim0810.workers.dev/api/refresh-sync?language=rust&range=daily" \
+  -H "Authorization: Bearer xK9mP2vL8nQ5wR7tY3zA4bN6cH1dF0eG"
+
+# Test scraping
+curl "https://hypegit.andrew-kim0810.workers.dev/api/test-scrape" \
+  -H "Authorization: Bearer xK9mP2vL8nQ5wR7tY3zA4bN6cH1dF0eG"
+```
+
+**Authentication errors:**
+
+Missing token:
+```json
+{
+  "error": "Unauthorized",
+  "message": "Missing Authorization header",
+  "hint": "Include: Authorization: Bearer YOUR_API_KEY"
+}
+```
+
+Invalid token:
+```json
+{
+  "error": "Unauthorized",
+  "message": "Invalid API key"
+}
+```
 
 ## Troubleshooting
 

--- a/hypegit/prisma/migrations/20251007155248_add_api_key_table.sql
+++ b/hypegit/prisma/migrations/20251007155248_add_api_key_table.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "key_hash" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used" DATETIME,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_by" TEXT
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_key_hash_key" ON "ApiKey"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_key_hash_idx" ON "ApiKey"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_is_active_idx" ON "ApiKey"("is_active");

--- a/hypegit/prisma/schema.prisma
+++ b/hypegit/prisma/schema.prisma
@@ -83,3 +83,18 @@ model RepositoryTopic {
 
   @@id([repo_id, topic_id])
 }
+
+// API Key management for authenticated endpoints
+model ApiKey {
+  id          String   @id
+  key_hash    String   @unique // SHA-256 hash of the API key
+  name        String   // Descriptive name (e.g., "Production CI/CD", "Admin Key")
+  description String?  // Optional description
+  created_at  DateTime @default(now())
+  last_used   DateTime?
+  is_active   Boolean  @default(true)
+  created_by  String?  // Optional: who created this key
+
+  @@index([key_hash])
+  @@index([is_active])
+}

--- a/hypegit/src/handlers/admin.ts
+++ b/hypegit/src/handlers/admin.ts
@@ -1,0 +1,153 @@
+/**
+ * Admin API handlers
+ * Key management endpoints (super admin only)
+ */
+
+import { Hono } from 'hono';
+import type { Env } from '../types/bindings';
+import { ApiKeyService } from '../services/apiKeyService';
+import { requireAdminAuth } from '../middleware/auth';
+
+/**
+ * Create admin route handlers
+ */
+export function createAdminHandlers() {
+  const app = new Hono<{ Bindings: Env }>();
+
+  // All admin routes require ADMIN_API_KEY
+  app.use('*', requireAdminAuth());
+
+  /**
+   * POST /admin/keys - Create a new API key
+   * Body:
+   *  - name: string (required)
+   *  - description: string (optional)
+   *  - created_by: string (optional)
+   */
+  app.post('/keys', async (c) => {
+    try {
+      const body = await c.req.json();
+
+      if (!body.name || typeof body.name !== 'string') {
+        return c.json({
+          error: 'Validation error',
+          message: 'name is required and must be a string'
+        }, 400);
+      }
+
+      const apiKeyService = new ApiKeyService(c.env);
+      const result = await apiKeyService.createApiKey({
+        name: body.name,
+        description: body.description,
+        created_by: body.created_by,
+      });
+
+      return c.json({
+        success: true,
+        message: 'API key created successfully. Save this key - it will not be shown again!',
+        key: result.key,
+        info: result.info,
+      }, 201);
+
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+
+  /**
+   * GET /admin/keys - List all API keys
+   * Query params:
+   *  - include_inactive: boolean (default: false)
+   */
+  app.get('/keys', async (c) => {
+    try {
+      const includeInactive = c.req.query('include_inactive') === 'true';
+
+      const apiKeyService = new ApiKeyService(c.env);
+      const keys = await apiKeyService.listKeys(includeInactive);
+
+      return c.json({
+        keys,
+        count: keys.length,
+        filters: {
+          include_inactive: includeInactive
+        }
+      });
+
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+
+  /**
+   * DELETE /admin/keys/:id - Deactivate an API key
+   */
+  app.delete('/keys/:id', async (c) => {
+    try {
+      const keyId = c.req.param('id');
+      const apiKeyService = new ApiKeyService(c.env);
+
+      await apiKeyService.deactivateKey(keyId);
+
+      return c.json({
+        success: true,
+        message: `API key ${keyId} deactivated successfully`
+      });
+
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+
+  /**
+   * POST /admin/keys/:id/reactivate - Reactivate an API key
+   */
+  app.post('/keys/:id/reactivate', async (c) => {
+    try {
+      const keyId = c.req.param('id');
+      const apiKeyService = new ApiKeyService(c.env);
+
+      await apiKeyService.reactivateKey(keyId);
+
+      return c.json({
+        success: true,
+        message: `API key ${keyId} reactivated successfully`
+      });
+
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+
+  /**
+   * DELETE /admin/keys/:id/permanent - Permanently delete an API key
+   */
+  app.delete('/keys/:id/permanent', async (c) => {
+    try {
+      const keyId = c.req.param('id');
+      const apiKeyService = new ApiKeyService(c.env);
+
+      await apiKeyService.deleteKey(keyId);
+
+      return c.json({
+        success: true,
+        message: `API key ${keyId} permanently deleted`
+      });
+
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+
+  return app;
+}

--- a/hypegit/src/handlers/api.ts
+++ b/hypegit/src/handlers/api.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono';
 import type { Env, ExecutionContext } from '../types/bindings';
 import { RepositoryService } from '../services/repositoryService';
 import { handleManualRefresh } from './cron';
+import { requireAuth } from '../middleware/auth';
 
 /**
  * Create API route handlers
@@ -197,8 +198,9 @@ export function createAPIHandlers() {
   /**
    * POST /api/refresh - Manual refresh trigger (background)
    * Triggers the daily trending scrape in background (may timeout)
+   * 🔒 Requires authentication
    */
-  app.post('/refresh', async (c) => {
+  app.post('/refresh', requireAuth(), async (c) => {
     try {
       const result = await handleManualRefresh(
         c.env,
@@ -220,8 +222,9 @@ export function createAPIHandlers() {
    * Query params:
    *   - language: typescript|python|go|rust|javascript|all
    *   - range: daily|weekly|monthly
+   * 🔒 Requires authentication
    */
-  app.post('/refresh-sync', async (c) => {
+  app.post('/refresh-sync', requireAuth(), async (c) => {
     try {
       const { handleDailyTrendingScrape } = await import('./cron');
       const language = c.req.query('language') || 'typescript';
@@ -299,10 +302,10 @@ export function createAPIHandlers() {
   });
 
   /**
-   * GET /api/trending - Get current trending (already exists above)
    * GET /api/test-scrape - Test scraping synchronously (for debugging)
+   * 🔒 Requires authentication
    */
-  app.get('/test-scrape', async (c) => {
+  app.get('/test-scrape', requireAuth(), async (c) => {
     try {
       const { TrendingScraperService } = await import('../services/trendingScraper');
       const scraper = new TrendingScraperService();

--- a/hypegit/src/index.ts
+++ b/hypegit/src/index.ts
@@ -8,6 +8,7 @@ import { cors } from 'hono/cors';
 import type { Env, ExecutionContext, ScheduledEvent } from './types/bindings';
 import { createHealthHandlers } from './handlers/health';
 import { createAPIHandlers } from './handlers/api';
+import { createAdminHandlers } from './handlers/admin';
 import { handleScheduledEvent } from './handlers/cron';
 
 /**
@@ -25,6 +26,10 @@ app.route('/', healthHandlers);
 // Mount API routes
 const apiHandlers = createAPIHandlers();
 app.route('/api', apiHandlers);
+
+// Mount admin routes (key management)
+const adminHandlers = createAdminHandlers();
+app.route('/admin', adminHandlers);
 
 // 404 handler
 app.notFound((c) => {

--- a/hypegit/src/middleware/auth.ts
+++ b/hypegit/src/middleware/auth.ts
@@ -1,0 +1,101 @@
+/**
+ * Authentication Middleware
+ * Bearer token validation for protected API endpoints
+ */
+
+import { bearerAuth } from 'hono/bearer-auth';
+import type { Context, MiddlewareHandler } from 'hono';
+import type { Env } from '../types/bindings';
+
+/**
+ * Create bearer authentication middleware
+ * Validates API key from Authorization header
+ */
+export function createAuthMiddleware(): MiddlewareHandler {
+  return async (c: Context<{ Bindings: Env }>, next) => {
+    const apiKey = c.env.ADMIN_API_KEY;
+
+    // If no API key is configured, deny all authenticated requests
+    if (!apiKey) {
+      return c.json({
+        error: 'Authentication not configured',
+        message: 'API key authentication is not properly set up'
+      }, 500);
+    }
+
+    // Use Hono's built-in bearer auth middleware
+    const auth = bearerAuth({ token: apiKey });
+    return auth(c, next);
+  };
+}
+
+/**
+ * Optional: Custom auth middleware with better error messages
+ */
+export function requireAuth(): MiddlewareHandler {
+  return async (c: Context<{ Bindings: Env }>, next) => {
+    const apiKey = c.env.ADMIN_API_KEY;
+
+    if (!apiKey) {
+      return c.json({
+        error: 'Authentication not configured',
+        message: 'API key authentication is not properly set up'
+      }, 500);
+    }
+
+    const authHeader = c.req.header('Authorization');
+
+    if (!authHeader) {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Missing Authorization header',
+        hint: 'Include: Authorization: Bearer YOUR_API_KEY'
+      }, 401);
+    }
+
+    const [scheme, token] = authHeader.split(' ');
+
+    if (scheme !== 'Bearer') {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Invalid authorization scheme',
+        hint: 'Use Bearer token: Authorization: Bearer YOUR_API_KEY'
+      }, 401);
+    }
+
+    if (!token) {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Missing API key',
+        hint: 'Include your API key after Bearer'
+      }, 401);
+    }
+
+    // Constant-time comparison to prevent timing attacks
+    if (!constantTimeCompare(token, apiKey)) {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Invalid API key'
+      }, 401);
+    }
+
+    // Authentication successful, proceed
+    await next();
+  };
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks
+ */
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+
+  return result === 0;
+}

--- a/hypegit/src/middleware/auth.ts
+++ b/hypegit/src/middleware/auth.ts
@@ -3,46 +3,16 @@
  * Bearer token validation for protected API endpoints
  */
 
-import { bearerAuth } from 'hono/bearer-auth';
 import type { Context, MiddlewareHandler } from 'hono';
 import type { Env } from '../types/bindings';
+import { ApiKeyService } from '../services/apiKeyService';
 
 /**
- * Create bearer authentication middleware
- * Validates API key from Authorization header
- */
-export function createAuthMiddleware(): MiddlewareHandler {
-  return async (c: Context<{ Bindings: Env }>, next) => {
-    const apiKey = c.env.ADMIN_API_KEY;
-
-    // If no API key is configured, deny all authenticated requests
-    if (!apiKey) {
-      return c.json({
-        error: 'Authentication not configured',
-        message: 'API key authentication is not properly set up'
-      }, 500);
-    }
-
-    // Use Hono's built-in bearer auth middleware
-    const auth = bearerAuth({ token: apiKey });
-    return auth(c, next);
-  };
-}
-
-/**
- * Optional: Custom auth middleware with better error messages
+ * Authentication middleware with database-backed API keys
+ * Also supports legacy ADMIN_API_KEY for backward compatibility
  */
 export function requireAuth(): MiddlewareHandler {
   return async (c: Context<{ Bindings: Env }>, next) => {
-    const apiKey = c.env.ADMIN_API_KEY;
-
-    if (!apiKey) {
-      return c.json({
-        error: 'Authentication not configured',
-        message: 'API key authentication is not properly set up'
-      }, 500);
-    }
-
     const authHeader = c.req.header('Authorization');
 
     if (!authHeader) {
@@ -71,15 +41,76 @@ export function requireAuth(): MiddlewareHandler {
       }, 401);
     }
 
-    // Constant-time comparison to prevent timing attacks
-    if (!constantTimeCompare(token, apiKey)) {
+    // Check database for API key
+    const apiKeyService = new ApiKeyService(c.env);
+    const keyInfo = await apiKeyService.validateKey(token);
+
+    if (keyInfo) {
+      // Valid database key - store key info in context for later use
+      c.set('apiKey', keyInfo);
+      await next();
+      return;
+    }
+
+    // Fallback: Check legacy ADMIN_API_KEY for backward compatibility
+    if (c.env.ADMIN_API_KEY && constantTimeCompare(token, c.env.ADMIN_API_KEY)) {
+      // Valid legacy admin key
+      c.set('apiKey', { name: 'Legacy Admin Key', id: 'admin' });
+      await next();
+      return;
+    }
+
+    // Invalid key
+    return c.json({
+      error: 'Unauthorized',
+      message: 'Invalid API key'
+    }, 401);
+  };
+}
+
+/**
+ * Super admin authentication (requires ADMIN_API_KEY only)
+ * Used for key management endpoints
+ */
+export function requireAdminAuth(): MiddlewareHandler {
+  return async (c: Context<{ Bindings: Env }>, next) => {
+    const adminKey = c.env.ADMIN_API_KEY;
+
+    if (!adminKey) {
+      return c.json({
+        error: 'Admin authentication not configured',
+        message: 'Admin API key is not set up'
+      }, 500);
+    }
+
+    const authHeader = c.req.header('Authorization');
+
+    if (!authHeader) {
       return c.json({
         error: 'Unauthorized',
-        message: 'Invalid API key'
+        message: 'Missing Authorization header',
+        hint: 'Include: Authorization: Bearer ADMIN_API_KEY'
       }, 401);
     }
 
-    // Authentication successful, proceed
+    const [scheme, token] = authHeader.split(' ');
+
+    if (scheme !== 'Bearer' || !token) {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Invalid authorization format'
+      }, 401);
+    }
+
+    // Constant-time comparison to prevent timing attacks
+    if (!constantTimeCompare(token, adminKey)) {
+      return c.json({
+        error: 'Unauthorized',
+        message: 'Invalid admin API key'
+      }, 401);
+    }
+
+    // Admin authentication successful
     await next();
   };
 }

--- a/hypegit/src/services/apiKeyService.ts
+++ b/hypegit/src/services/apiKeyService.ts
@@ -1,0 +1,166 @@
+/**
+ * API Key Management Service
+ * Handles creation, validation, and management of API keys
+ */
+
+import { PrismaD1 } from '@prisma/adapter-d1';
+import { PrismaClient } from '@prisma/client';
+import type { Env } from '../types/bindings';
+
+export interface CreateApiKeyInput {
+  name: string;
+  description?: string;
+  created_by?: string;
+}
+
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: Date;
+  last_used: Date | null;
+  is_active: boolean;
+  created_by: string | null;
+}
+
+export class ApiKeyService {
+  private prisma: PrismaClient;
+
+  constructor(env: Env) {
+    const adapter = new PrismaD1(env.HYPEGIT_DB);
+    this.prisma = new PrismaClient({ adapter });
+  }
+
+  /**
+   * Generate a new API key
+   * Returns the plaintext key (only shown once) and the key info
+   */
+  async createApiKey(input: CreateApiKeyInput): Promise<{ key: string; info: ApiKeyInfo }> {
+    // Generate a secure random API key (32 bytes = 44 chars base64)
+    const keyBytes = new Uint8Array(32);
+    crypto.getRandomValues(keyBytes);
+    const key = btoa(String.fromCharCode(...keyBytes));
+
+    // Hash the key for storage (SHA-256)
+    const keyHash = await this.hashKey(key);
+
+    // Store in database
+    const apiKey = await this.prisma.apiKey.create({
+      data: {
+        id: crypto.randomUUID(),
+        key_hash: keyHash,
+        name: input.name,
+        description: input.description || null,
+        created_by: input.created_by || null,
+        is_active: true,
+      },
+    });
+
+    return {
+      key, // Return plaintext key (only time it's visible)
+      info: {
+        id: apiKey.id,
+        name: apiKey.name,
+        description: apiKey.description,
+        created_at: apiKey.created_at,
+        last_used: apiKey.last_used,
+        is_active: apiKey.is_active,
+        created_by: apiKey.created_by,
+      },
+    };
+  }
+
+  /**
+   * Validate an API key
+   * Returns the key info if valid, null if invalid
+   */
+  async validateKey(key: string): Promise<ApiKeyInfo | null> {
+    const keyHash = await this.hashKey(key);
+
+    const apiKey = await this.prisma.apiKey.findUnique({
+      where: { key_hash: keyHash },
+    });
+
+    if (!apiKey || !apiKey.is_active) {
+      return null;
+    }
+
+    // Update last_used timestamp asynchronously (don't wait)
+    this.prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { last_used: new Date() },
+    }).catch(err => {
+      console.error('Failed to update last_used:', err);
+    });
+
+    return {
+      id: apiKey.id,
+      name: apiKey.name,
+      description: apiKey.description,
+      created_at: apiKey.created_at,
+      last_used: apiKey.last_used,
+      is_active: apiKey.is_active,
+      created_by: apiKey.created_by,
+    };
+  }
+
+  /**
+   * List all API keys
+   */
+  async listKeys(includeInactive: boolean = false): Promise<ApiKeyInfo[]> {
+    const keys = await this.prisma.apiKey.findMany({
+      where: includeInactive ? undefined : { is_active: true },
+      orderBy: { created_at: 'desc' },
+    });
+
+    return keys.map(key => ({
+      id: key.id,
+      name: key.name,
+      description: key.description,
+      created_at: key.created_at,
+      last_used: key.last_used,
+      is_active: key.is_active,
+      created_by: key.created_by,
+    }));
+  }
+
+  /**
+   * Deactivate an API key
+   */
+  async deactivateKey(keyId: string): Promise<void> {
+    await this.prisma.apiKey.update({
+      where: { id: keyId },
+      data: { is_active: false },
+    });
+  }
+
+  /**
+   * Reactivate an API key
+   */
+  async reactivateKey(keyId: string): Promise<void> {
+    await this.prisma.apiKey.update({
+      where: { id: keyId },
+      data: { is_active: true },
+    });
+  }
+
+  /**
+   * Delete an API key permanently
+   */
+  async deleteKey(keyId: string): Promise<void> {
+    await this.prisma.apiKey.delete({
+      where: { id: keyId },
+    });
+  }
+
+  /**
+   * Hash an API key using SHA-256
+   */
+  private async hashKey(key: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(key);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+}

--- a/hypegit/src/types/bindings.ts
+++ b/hypegit/src/types/bindings.ts
@@ -12,6 +12,7 @@ export interface Env {
 
   // Secrets
   GITHUB_TOKEN: string;
+  ADMIN_API_KEY: string;  // Bearer token for protected API endpoints
 
   // Environment variables
   ENVIRONMENT: string;


### PR DESCRIPTION
## Summary
Implements comprehensive API authentication system with database-backed key management.

## Changes

### Phase 1: Bearer Token Authentication (Initial Commit)
- ✅ Created authentication middleware with constant-time token comparison
- ✅ Protected POST endpoints: `/api/refresh`, `/api/refresh-sync`
- ✅ Protected debug endpoint: `/api/test-scrape`
- ✅ Added `ADMIN_API_KEY` to environment bindings
- ✅ All read endpoints remain public

### Phase 2: Database-Backed API Keys (Current Commit)
- ✅ Added `ApiKey` table to Prisma schema with SHA-256 hashed keys
- ✅ Created `ApiKeyService` for key lifecycle management
- ✅ Updated auth middleware to check database first, fallback to legacy admin key
- ✅ Added admin endpoints for key management:
  - `POST /admin/keys` - Create new API key
  - `GET /admin/keys` - List all keys
  - `DELETE /admin/keys/:id` - Deactivate key
  - `POST /admin/keys/:id/reactivate` - Reactivate key
  - `DELETE /admin/keys/:id/permanent` - Permanently delete key
- ✅ Track `last_used` timestamp and `is_active` status
- ✅ Generate secure 32-byte random keys
- ✅ Updated documentation with complete key management guide

## Architecture

### Two-Tier Authentication System
1. **Database API Keys** (Recommended)
   - Stored in D1 database as SHA-256 hashes
   - Support multiple keys with metadata (name, description, created_by)
   - Can be managed via admin endpoints
   - Last used timestamp tracking
   - Enable/disable without deletion

2. **ADMIN_API_KEY** (Legacy/Super Admin)
   - Stored in Wrangler secrets
   - Required for admin endpoints
   - Backward compatible with existing deployments
   - Used for key management operations

### Endpoints

**Protected Endpoints** (require any valid API key):
- `POST /api/refresh` - Manual background scrape
- `POST /api/refresh-sync` - Synchronous scrape
- `GET /api/test-scrape` - Debug endpoint

**Admin Endpoints** (require ADMIN_API_KEY only):
- `POST /admin/keys` - Create API key
- `GET /admin/keys` - List keys
- `DELETE /admin/keys/:id` - Deactivate
- `POST /admin/keys/:id/reactivate` - Reactivate
- `DELETE /admin/keys/:id/permanent` - Delete

**Public Endpoints** (no auth):
- `GET /api/repos` - List repositories
- `GET /api/trending` - Current trending
- `GET /api/stats` - Platform statistics
- `GET /health` - Health check

## Test Results

✅ **Database key creation**: Successfully created test key  
✅ **Database key authentication**: Works on protected endpoints  
✅ **Legacy admin key**: Still works for backward compatibility  
✅ **Key listing**: Returns all active keys with metadata  
✅ **Admin endpoints**: Require ADMIN_API_KEY specifically  
✅ **Public endpoints**: Remain accessible without auth  

## Security Features

- SHA-256 hashing for stored keys
- Constant-time comparison to prevent timing attacks
- Keys shown only once during creation
- Separate admin key for key management
- Automatic last_used timestamp tracking
- Soft delete support (deactivate vs permanent delete)

## Example Usage

### Create a new API key:
```bash
curl -X POST "https://hypegit.andrew-kim0810.workers.dev/admin/keys" \
  -H "Authorization: Bearer ADMIN_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "CI/CD Pipeline",
    "description": "Automated deployments"
  }'
```

### Use the API key:
```bash
curl -X POST "https://hypegit.andrew-kim0810.workers.dev/api/refresh" \
  -H "Authorization: Bearer NEW_API_KEY"
```

Resolves https://linear.app/baobab-tree/issue/ANDY-56/authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)