### PR TITLE
fix: add daily repository snapshot batching

### DIFF
--- a/hypegit/src/handlers/cron.ts
+++ b/hypegit/src/handlers/cron.ts
@@ -69,7 +69,24 @@ export async function handleScheduledEvent(
       }
     }
 
-    console.log(`📤 Queuing ${messages.length} scraping tasks...`);
+    // Add repository snapshot batch messages
+    // Process all repos in batches of 50
+    const batchSize = 50;
+    const estimatedTotalRepos = 4000; // Estimate, will stop early if no repos found
+    const numBatches = Math.ceil(estimatedTotalRepos / batchSize);
+
+    for (let i = 0; i < numBatches; i++) {
+      messages.push({
+        body: {
+          task: 'snapshot-repos' as const,
+          date: today,
+          batchOffset: i * batchSize,
+          batchLimit: batchSize,
+        }
+      });
+    }
+
+    console.log(`📤 Queuing ${messages.length} tasks (63 trending + ${numBatches} snapshot batches)...`);
 
     // Send all messages to the queue
     await env.SCRAPER_QUEUE.sendBatch(messages);

--- a/hypegit/src/types/bindings.ts
+++ b/hypegit/src/types/bindings.ts
@@ -171,6 +171,7 @@ export interface ScraperQueueMessage {
   range?: 'daily' | 'weekly' | 'monthly';
   language?: string | null;
   date: string;
-  // For repository snapshots (if we use queue for this too):
-  repoIds?: string[];
+  // For repository snapshots batch processing:
+  batchOffset?: number;
+  batchLimit?: number;
 }


### PR DESCRIPTION
## Summary
- Fix incomplete daily StarSnapshot captures (~1,200/day instead of 3,633+)
- Add batch-based snapshot processing for all existing repositories
- Queue 80 snapshot batch tasks (50 repos each) alongside 63 trending scrape tasks

## Problem
Only repositories found on trending pages were being snapshotted daily, resulting in ~1,200 snapshots instead of all 3,633+ repositories.

## Solution
- Add `batchOffset`/`batchLimit` to queue message type
- Update `handleSnapshotRepos` to query database for repos at given offset
- Cron handler now queues 143 tasks: 63 trending + 80 snapshot batches

## Test plan
- [ ] Deploy and verify next cron run snapshots all repos
- [ ] Check `SELECT DATE(captured_at), COUNT(*) FROM StarSnapshot GROUP BY 1` shows ~3,633 snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)